### PR TITLE
go run -race precode.go не нашёл никаких гонок

### DIFF
--- a/precode.go
+++ b/precode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"time"
 )
 
 // Generator генерирует последовательность чисел 1,2,3 и т.д. и
@@ -12,21 +13,46 @@ import (
 // вызывается функция fn. Она служит для подсчёта количества и суммы
 // сгенерированных чисел.
 func Generator(ctx context.Context, ch chan<- int64, fn func(int64)) {
+	defer close(ch)
+	var i int64 = 1
 	// 1. Функция Generator
-	// ...
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			ch <- i
+			fn(i)
+			i++
+		}
+	}
 }
 
 // Worker читает число из канала in и пишет его в канал out.
 func Worker(in <-chan int64, out chan<- int64) {
 	// 2. Функция Worker
-	// ...
+	defer close(out)
+	v, ok := <-in
+	if !ok {
+		return
+	}
+	out <- v
+	for {
+		v, ok = <-in
+		if !ok {
+			return
+		}
+		out <- v
+		time.Sleep(1 * time.Millisecond)
+	}
 }
 
 func main() {
 	chIn := make(chan int64)
 
 	// 3. Создание контекста
-	// ...
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
 
 	// для проверки будем считать количество и сумму отправленных чисел
 	var inputSum int64   // сумма сгенерированных чисел
@@ -55,7 +81,16 @@ func main() {
 	var wg sync.WaitGroup
 
 	// 4. Собираем числа из каналов outs
-	// ...
+	for i, v := range outs {
+		wg.Add(1)
+		go func(v <-chan int64, i int) {
+			defer wg.Done()
+			for n := range v {
+				amounts[i]++
+				chOut <- n
+			}
+		}(v, int(i))
+	}
 
 	go func() {
 		// ждём завершения работы всех горутин для outs
@@ -68,7 +103,15 @@ func main() {
 	var sum int64   // сумма чисел результирующего канала
 
 	// 5. Читаем числа из результирующего канала
-	// ...
+	num, ok := <-chOut
+	for {
+		if !ok {
+			break
+		}
+		count++
+		sum += num
+		num, ok = <-chOut
+	}
 
 	fmt.Println("Количество чисел", inputCount, count)
 	fmt.Println("Сумма чисел", inputSum, sum)


### PR DESCRIPTION
Здравствуйте, в задании было сказанно мол поищите где может возникнуть гонка и захерачьте её мьютексами, я прогнал go run -race и он ничего не нашёл, но чисто в теории мьютексы нужны внутри функции worker, в случае моего кода mu.Lock()+defer mu.Unlock следовало бы добавить перед 89 строчкой (воткуть переменную amounts в мьютексы).
Все остальные горутины находящиеся в цикле обращаются исключительно к каналам которым мьютексы не нужны. А те что работают с переменными не находятся в цикле (то есть с этими переменными в данный момент работает лишь одна горутина)